### PR TITLE
Update defaults to increase swipe animation speed

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ This prop can also accept an object whose keys are swipe axis ("x" and "y") and 
 
 `payload` is a gesture-handler payload that you can use to customize the config.
 
-Default value: `{ x: ({ velocityX }) => ({ velocity: 0.0001 * velocityX, mass: 1, damping: 100, stiffness: 200 }), y: ({ velocityY }) => ({ velocity: 0.0001 * velocityY, mass: 1, damping: 100, stiffness: 200 }) }`.
+Default value: `() => ({ duration: 300 })`.
 
 #### ▶️ imperativeSwipeAnimationConfig
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ For example, if you set `validatedSwipeTranslationThreshold` to 200 and the user
 
 A swipe can also be validated if the velocity is high enough, see `validateSwipeVelocityThreshold`.
 
-Default value: `{ x: 0.5 * screenWidth, y: 0.25 * screenHeight }`.
+Default value: `{ x: 0.4 * screenWidth, y: 0.25 * screenHeight }`.
 
 #### ▶️ validateSwipeVelocityThreshold
 

--- a/library/package.json
+++ b/library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-swipeable-card-stack",
   "description": "Implement a swipeable card stack, similar to Tinder, with ease.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "dist/index.js",
   "repository": "https://github.com/antoine-cottineau/react-native-swipeable-card-stack",
   "author": "Antoine Cottineau",

--- a/library/src/view/SwipeableCardStackOptions.ts
+++ b/library/src/view/SwipeableCardStackOptions.ts
@@ -47,7 +47,7 @@ export type SwipeableCardStackOptions = {
    *
    * A swipe can also be validated if the velocity is high enough, see `validateSwipeVelocityThreshold`.
    *
-   * Default value: `{ x: 0.5 * screenWidth, y: 0.25 * screenHeight }`.
+   * Default value: `{ x: 0.4 * screenWidth, y: 0.25 * screenHeight }`.
    */
   validateSwipeTranslationThreshold: SwipeAxisDependentProp<number>
 

--- a/library/src/view/SwipeableCardStackOptions.ts
+++ b/library/src/view/SwipeableCardStackOptions.ts
@@ -69,7 +69,7 @@ export type SwipeableCardStackOptions = {
    *
    * `payload` is a gesture-handler payload that you can use to customize the config.
    *
-   * Default value: `{ x: ({ velocityX }) => ({ velocity: 0.0001 * velocityX, mass: 1, damping: 100, stiffness: 200 }), y: ({ velocityY }) => ({ velocity: 0.0001 * velocityY, mass: 1, damping: 100, stiffness: 200 }) }`.
+   * Default value: `() => ({ duration: 300 })`.
    */
   validatedSwipeAnimationConfig: SwipeAxisDependentProp<
     (payload: PanGestureHandlerEventPayload) => WithSpringConfig

--- a/library/src/view/useDefaultOptions.ts
+++ b/library/src/view/useDefaultOptions.ts
@@ -12,7 +12,7 @@ export const useDefaultOptions = (): SwipeableCardStackOptions => {
       y: 1 * height,
     },
     validateSwipeTranslationThreshold: {
-      x: 0.5 * width,
+      x: 0.4 * width,
       y: 0.25 * height,
     },
     validateSwipeVelocityThreshold: 800,

--- a/library/src/view/useDefaultOptions.ts
+++ b/library/src/view/useDefaultOptions.ts
@@ -16,20 +16,7 @@ export const useDefaultOptions = (): SwipeableCardStackOptions => {
       y: 0.25 * height,
     },
     validateSwipeVelocityThreshold: 800,
-    validatedSwipeAnimationConfig: {
-      x: ({ velocityX }) => ({
-        velocity: 0.0001 * velocityX,
-        mass: 1,
-        damping: 100,
-        stiffness: 200,
-      }),
-      y: ({ velocityY }) => ({
-        velocity: 0.0001 * velocityY,
-        mass: 1,
-        damping: 100,
-        stiffness: 200,
-      }),
-    },
+    validatedSwipeAnimationConfig: () => ({ duration: 300 }),
     imperativeSwipeAnimationConfig: {
       duration: 300,
       easing: Easing.inOut(Easing.quad),


### PR DESCRIPTION
The previous default animation config made the swipes take between 550 and 650ms between the states "validated" and "ended".
This is too much and delayed the next card being touchable.