### PR TITLE
Prevent blocking gestures on next cards

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-swipeable-card-stack",
   "description": "Implement a swipeable card stack, similar to Tinder, with ease.",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "dist/index.js",
   "repository": "https://github.com/antoine-cottineau/react-native-swipeable-card-stack",
   "author": "Antoine Cottineau",

--- a/library/src/view/SwipeableCardWrapper.tsx
+++ b/library/src/view/SwipeableCardWrapper.tsx
@@ -208,7 +208,6 @@ export const SwipeableCardWrapper = forwardRef(function SwipeableCardWrapper(
       xAnimationPosition.value = targetAnimationPosition
       yAnimationPosition.value = targetAnimationPosition
     })
-    .enabled(status === 'current')
     .withTestId(`swipeable-card-wrapper-${index}-gesture`)
 
   const animatedStyle = useAnimatedStyle(() => ({


### PR DESCRIPTION
This caused delayed between the first card finishing its animation and the second one being activated