### PR TITLE
Prevent SwipeableCardStack from capturing pointer events

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-swipeable-card-stack",
   "description": "Implement a swipeable card stack, similar to Tinder, with ease.",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "dist/index.js",
   "repository": "https://github.com/antoine-cottineau/react-native-swipeable-card-stack",
   "author": "Antoine Cottineau",

--- a/library/src/view/SwipeableCardStack.tsx
+++ b/library/src/view/SwipeableCardStack.tsx
@@ -63,7 +63,7 @@ const SwipeableCardStackMemo = forwardRef(function SwipeableCardStack<T>(
   )
 
   return (
-    <View style={styles.container}>
+    <View style={styles.container} pointerEvents="box-none">
       {toReversed(data).map((cardData, reverseIndex) => {
         const index = data.length - reverseIndex - 1
 

--- a/library/src/view/__snapshots__/SwipeableCardStack.test.tsx.snap
+++ b/library/src/view/__snapshots__/SwipeableCardStack.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`correctly renders 1`] = `
 <View
+  pointerEvents="box-none"
   style={
     {
       "flex": 1,


### PR DESCRIPTION
This was blocking any click on views behind the stack, even if there was no cards left.